### PR TITLE
IIO blocks for GnuRadio

### DIFF
--- a/gr-iio.lwr
+++ b/gr-iio.lwr
@@ -1,0 +1,25 @@
+#
+# This file is part of PyBOMBS
+#
+# PyBOMBS is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3, or (at your option)
+# any later version.
+#
+# PyBOMBS is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with PyBOMBS; see the file COPYING.  If not, write to
+# the Free Software Foundation, Inc., 51 Franklin Street,
+# Boston, MA 02110-1301, USA.
+#
+
+category: common
+depends: gnuradio libiio
+satisfy_deb: gr-iio
+source: git://https://github.com/analogdevicesinc/gnuradio.git
+gitbranch: gr-iio
+inherit: cmake

--- a/libiio.lwr
+++ b/libiio.lwr
@@ -1,0 +1,25 @@
+#
+# This file is part of PyBOMBS
+#
+# PyBOMBS is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3, or (at your option)
+# any later version.
+#
+# PyBOMBS is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with PyBOMBS; see the file COPYING.  If not, write to
+# the Free Software Foundation, Inc., 51 Franklin Street,
+# Boston, MA 02110-1301, USA.
+#
+
+depends: libxml cmake git
+category: hardware
+satisfy_deb: libiio0 >= 0.5 && libiio-dev >= 0.5
+source: git://https://github.com/analogdevicesinc/libiio
+gitrev: tags/v0.5
+inherit: cmake


### PR DESCRIPTION
This pull request is for adding two new recipes: one for "libiio", the library used to interface with Industrial I/O (IIO) devices through the IIO framework of the Linux kernel.
The second recipe is for "gr-iio", a set of GnuRadio blocks that use the libiio library to source or submit samples from/to IIO hardware.
