### PR TITLE
add gr-nacl recipe

### DIFF
--- a/gr-nacl.lwr
+++ b/gr-nacl.lwr
@@ -1,0 +1,24 @@
+#
+# This file is part of PyBOMBS
+#
+# PyBOMBS is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3, or (at your option)
+# any later version.
+#
+# PyBOMBS is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with PyBOMBS; see the file COPYING.  If not, write to
+# the Free Software Foundation, Inc., 51 Franklin Street,
+# Boston, MA 02110-1301, USA.
+#
+
+depends: gnuradio 
+category: common
+source: git://https://github.com/stwunsch/gr-nacl.git
+gitbranch: master
+inherit: cmake

--- a/libsodium.lwr
+++ b/libsodium.lwr
@@ -17,8 +17,12 @@
 # Boston, MA 02110-1301, USA.
 #
 
-depends: gnuradio libsodium
-category: common
-source: git://https://github.com/stwunsch/gr-nacl.git
+category: baseline
+depends: make git autoconf automake
+source: git://https://github.com/jedisct1/libsodium.git
 gitbranch: master
-inherit: cmake
+inherit: autoconf
+configure {
+    autoreconf -i
+    ./configure --prefix=$prefix $config_opt
+    }


### PR DESCRIPTION
Libsodium dependency not included in recipe (needs to be compiled and installed by hand, is not available via package manager), installation is fully explained in gr-nacl/README.md
