### PR TITLE
adds recipe for Apache Thrift.

### DIFF
--- a/apache-thrift.lwr
+++ b/apache-thrift.lwr
@@ -1,0 +1,30 @@
+#
+# This file is part of PyBOMBS
+#
+# PyBOMBS is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3, or (at your option)
+# any later version.
+#
+# PyBOMBS is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with PyBOMBS; see the file COPYING.  If not, write to
+# the Free Software Foundation, Inc., 51 Franklin Street,
+# Boston, MA 02110-1301, USA.
+#
+
+depends: automake gcc boost bison flex libevent python ssl
+category: baseline
+source: wget://http://apache.mesi.com.ar/thrift/0.9.2/thrift-0.9.2.tar.gz
+inherit: autoconf
+configure {
+    ./configure --prefix=$prefix $config_opt \
+    --enable-tests --disable-tutorial --with-cpp --with-python \
+    --with-c_glib --with-java --without-csharp --without-php \
+    --with-libevent --without-zlib \
+    CC=$cc CXX=$cxx
+}

--- a/libevent.lwr
+++ b/libevent.lwr
@@ -1,0 +1,23 @@
+#
+# This file is part of PyBOMBS
+#
+# PyBOMBS is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3, or (at your option)
+# any later version.
+#
+# PyBOMBS is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with PyBOMBS; see the file COPYING.  If not, write to
+# the Free Software Foundation, Inc., 51 Franklin Street,
+# Boston, MA 02110-1301, USA.
+#
+
+category: baseline
+depends: ssl
+satisfy_deb: libevent-dev
+satisfy_rpm: libevent-devel


### PR DESCRIPTION
Depends on libevent, which is apt-get and yum installable. No source
install for this library provided.
