### PR TITLE
fcdpro+ is a hardware-specific module, not a "common" module

### DIFF
--- a/gr-fcdproplus.lwr
+++ b/gr-fcdproplus.lwr
@@ -17,7 +17,7 @@
 # Boston, MA 02110-1301, USA.
 #
 
-category: common
+category: hardware
 depends: gnuradio libusb libhidapi
 satisfy_deb: gr-fcdproplus && qthid-fcd-controller
 source: git://https://github.com/dl1ksv/gr-fcdproplus.git


### PR DESCRIPTION
This moves gr-fcdproplus to the hardware category, like airspy or hackrf.

Somewhat related to https://github.com/gnuradio/pybombs/pull/164
