### PR TITLE
Added recipes for gr-streamsink and libmp3lame

### DIFF
--- a/gr-streamsink.lwr
+++ b/gr-streamsink.lwr
@@ -1,0 +1,24 @@
+#
+# This file is part of PyBOMBS
+#
+# PyBOMBS is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3, or (at your option)
+# any later version.
+#
+# PyBOMBS is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with PyBOMBS; see the file COPYING.  If not, write to
+# the Free Software Foundation, Inc., 51 Franklin Street,
+# Boston, MA 02110-1301, USA.
+#
+
+category: common
+depends: gnuradio libmp3lame
+source: git://https://github.com/martinleolehner/gr-streamsink.git
+gitbranch: master
+inherit: cmake

--- a/libmp3lame.lwr
+++ b/libmp3lame.lwr
@@ -1,0 +1,21 @@
+#
+# This file is part of PyBOMBS
+#
+# PyBOMBS is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3, or (at your option)
+# any later version.
+#
+# PyBOMBS is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with PyBOMBS; see the file COPYING.  If not, write to
+# the Free Software Foundation, Inc., 51 Franklin Street,
+# Boston, MA 02110-1301, USA.
+#
+
+category: baseline
+satisfy_deb: libmp3lame-dev


### PR DESCRIPTION
Added recipes for gr-streamsink and libmp3lame.

gr-streamsink is a GNURadio sink block to stream the audio to SHOUTcast or Icecast. It depends on lame (libmp3lame-dev). See https://github.com/martinleolehner/gr-streamsink
