### PR TITLE
prevent build from picking up unwanted languages

### DIFF
--- a/apache-thrift.lwr
+++ b/apache-thrift.lwr
@@ -26,6 +26,7 @@ configure {
     ./bootstrap.sh && ./configure --prefix=$prefix $config_opt \
     --enable-tests --disable-tutorial --with-cpp --with-python \
     --with-c_glib --with-java --without-csharp --without-php \
-    --with-libevent --without-zlib \
+    --without-ruby --without-lua --without-nodejs --without-erlang \
+    --without-go --without-haskell --with-libevent --without-zlib \
     CC=$cc CXX=$cxx PY_PREFIX=$prefix
 }


### PR DESCRIPTION
I have lua installed, but not lua-dev, so the build was failing because it couldn't find lua.h. This patch disables most of the unnecessary languages.
