### PR TITLE
move these to "application" category

### DIFF
--- a/gnss-sdr.lwr
+++ b/gnss-sdr.lwr
@@ -17,7 +17,7 @@
 # Boston, MA 02110-1301, USA.
 #
 
-category: common
+category: application
 depends: gnuradio armadillo
 source: git://http://github.com/gnss-sdr/gnss-sdr.git
 gitbranch: next

--- a/gqrx-digital.lwr
+++ b/gqrx-digital.lwr
@@ -17,7 +17,7 @@
 # Boston, MA 02110-1301, USA.
 #
 
-category: common
+category: application
 depends: gnuradio gr-osmosdr pulseaudio qt4 libosmocore osmo-tetra libshout gr-dsd
 source: git://https://github.com/kantooon/gqrx_fork.git
 gitbranch: digital

--- a/gqrx.lwr
+++ b/gqrx.lwr
@@ -17,7 +17,7 @@
 # Boston, MA 02110-1301, USA.
 #
 
-category: common
+category: application
 depends: gnuradio gr-osmosdr pulseaudio qt4
 satisfy_deb: gqrx-sdr
 source: git://https://github.com/csete/gqrx.git


### PR DESCRIPTION
This patch moves gqrx\* and gnss-sdr to the application category. These are top-level applications that a user could run, compared to some of the other libraries that provide some blocks, but not an end user application...
