### PR TITLE
libiio: Don't build the IIOD server

### DIFF
--- a/libiio.lwr
+++ b/libiio.lwr
@@ -22,4 +22,5 @@ category: hardware
 satisfy_deb: libiio0 >= 0.5 && libiio-dev >= 0.5
 source: git://https://github.com/analogdevicesinc/libiio
 gitrev: tags/v0.5
+var config_opt = " -DWITH_IIOD:BOOL=OFF "
 inherit: cmake


### PR DESCRIPTION
It is not needed and adds unmet dependencies on bison and flex.

Signed-off-by: Paul Cercueil paul.cercueil@analog.com
