### PR TITLE
fix checkout when using 'single-branch' git option

### DIFF
--- a/apache-thrift.lwr
+++ b/apache-thrift.lwr
@@ -20,7 +20,7 @@
 depends: libtool automake gcc boost bison flex libevent python ssl
 category: baseline
 source: git://https://git-wip-us.apache.org/repos/asf/thrift.git
-gitrev: 0.9.2
+gitbranch: 0.9.2
 inherit: bootstrapautoconf
 configure {
     ./bootstrap.sh && ./configure --prefix=$prefix $config_opt \


### PR DESCRIPTION
Fixes "error: pathspec '0.9.2' did not match any file(s) known to git." Thanks to @jmcorgan for the clue-stick.
