### PR TITLE
Change source to http for osmocom based repos

### DIFF
--- a/gr-fosphor.lwr
+++ b/gr-fosphor.lwr
@@ -19,7 +19,7 @@
 
 category: common
 depends: gnuradio glfw3
-source: git://git://git.osmocom.org/gr-fosphor
+source: git://http://git.osmocom.org/gr-fosphor
 gitbranch: master
 # NOTE: If cmake does not find your libOpenCL.so you may
 #       need to uncomment and update the following line!

--- a/gr-iqbal.lwr
+++ b/gr-iqbal.lwr
@@ -20,6 +20,6 @@
 category: common
 depends: gnuradio libosmo-dsp
 satisfy_deb: gr-iqbal
-source: git://git://git.osmocom.org/gr-iqbal
+source: git://http://git.osmocom.org/gr-iqbal
 gitbranch: master
 inherit: cmake

--- a/gr-osmosdr.lwr
+++ b/gr-osmosdr.lwr
@@ -20,6 +20,6 @@
 category: common
 depends: uhd rtl-sdr osmo-sdr hackrf gnuradio gr-iqbal bladeRF
 satisfy_deb: gr-osmosdr
-source: git://git://git.osmocom.org/gr-osmosdr
+source: git://http://git.osmocom.org/gr-osmosdr
 gitbranch: master
 inherit: cmake

--- a/libosmo-dsp.lwr
+++ b/libosmo-dsp.lwr
@@ -21,7 +21,7 @@
 
 category: dsplib
 depends: fftw autoconf libtool automake
-source: git://git://git.osmocom.org/libosmo-dsp
+source: git://http://git.osmocom.org/libosmo-dsp
 gitbranch: master
 inherit: autoconf
 

--- a/libosmocore.lwr
+++ b/libosmocore.lwr
@@ -21,7 +21,7 @@
 
 category: dsplib
 depends: libtool automake
-source: git://git://git.osmocom.org/libosmocore.git
+source: git://http://git.osmocom.org/libosmocore.git
 gitbranch: master
 inherit: autoconf
 

--- a/osmo-sdr.lwr
+++ b/osmo-sdr.lwr
@@ -20,7 +20,7 @@
 category: hardware
 depends: git cmake libusb
 satisfy_deb: osmo-sdr && libosmosdr-dev
-source: git://git://git.osmocom.org/osmo-sdr.git
+source: git://http://git.osmocom.org/osmo-sdr.git
 gitbranch: master
 inherit: cmake
 

--- a/osmo-tetra.lwr
+++ b/osmo-tetra.lwr
@@ -19,7 +19,7 @@
 
 category: dsplib
 depends:
-source: git://git://git.osmocom.org/osmo-tetra.git
+source: git://http://git.osmocom.org/osmo-tetra.git
 gitbranch: master
 #inherit: autoconf
 

--- a/rtl-sdr.lwr
+++ b/rtl-sdr.lwr
@@ -20,7 +20,7 @@
 category: hardware
 depends: libusb
 satisfy_deb: rtl-sdr && librtlsdr-dev
-source: git://git://git.osmocom.org/rtl-sdr
+source: git://http://git.osmocom.org/rtl-sdr
 gitbranch: master
 var config_opt = " -DDETACH_KERNEL_DRIVER=ON "
 inherit: cmake


### PR DESCRIPTION
Currently osmocom based recipes' sources point to git, which may
not be accessible from behind a corporate proxy. This commit
changes the source to point to git repos hosted on a http
server
