### PR TITLE
add gr-display

### DIFF
--- a/gr-display.lwr
+++ b/gr-display.lwr
@@ -1,0 +1,24 @@
+#
+# This file is part of PyBOMBS
+#
+# PyBOMBS is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3, or (at your option)
+# any later version.
+#
+# PyBOMBS is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with PyBOMBS; see the file COPYING.  If not, write to
+# the Free Software Foundation, Inc., 51 Franklin Street,
+# Boston, MA 02110-1301, USA.
+#
+
+category: common
+depends: gnuradio
+source: git://https://github.com/dl1ksv/gr-display.git
+gitbranch: master
+inherit: cmake


### PR DESCRIPTION
gr-display is a small qt based addon for gnuradio.

It contains two components:
show_image   - to display png images.
show_text    - to display ascii characters as text in a qt window.
