### PR TITLE
recipe for gr-isdbt, a receiver for ISDB-T

### DIFF
--- a/gr-isdbt.lwr
+++ b/gr-isdbt.lwr
@@ -1,0 +1,24 @@
+#
+# This file is part of PyBOMBS
+#
+# PyBOMBS is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3, or (at your option)
+# any later version.
+#
+# PyBOMBS is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with PyBOMBS; see the file COPYING.  If not, write to
+# the Free Software Foundation, Inc., 51 Franklin Street,
+# Boston, MA 02110-1301, USA.
+#
+
+category: common
+depends: gnuradio
+source: git://https://github.com/git-artes/gr-isdbt
+gitbranch: master
+inherit: cmake


### PR DESCRIPTION
ISDB-T receiver in GNU Radio. An open source implementation of a receiver for the Digital Television standard ISDB-T (ARIB's STD-B31) in GNU Radio.
