### PR TITLE
ads-b decoder, by @wnagele

### DIFF
--- a/gr-adsb.lwr
+++ b/gr-adsb.lwr
@@ -1,0 +1,24 @@
+#
+# This file is part of PyBOMBS
+#
+# PyBOMBS is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3, or (at your option)
+# any later version.
+#
+# PyBOMBS is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with PyBOMBS; see the file COPYING.  If not, write to
+# the Free Software Foundation, Inc., 51 Franklin Street,
+# Boston, MA 02110-1301, USA.
+#
+
+category: common
+depends: gnuradio
+source: git://https://github.com/wnagele/gr-adsb.git
+gitbranch: master
+inherit: cmake


### PR DESCRIPTION
"Python framer and decoder blocks for processing ADSB messages in GNU Radio. Includes example flow graph for end-to-end processing of messages."
