### PR TITLE
simple_radio_astronomy now lives on github

### DIFF
--- a/gr-ra_blocks.lwr
+++ b/gr-ra_blocks.lwr
@@ -17,8 +17,9 @@
 # Boston, MA 02110-1301, USA.
 #
 
-category: application
-depends: gnuradio gr-ra_blocks
-source: git://https://github.com/patchvonbraun/simple_ra.git
+category: common
+depends: gnuradio
+source: git://https://github.com/patchvonbraun/gr-ra_blocks.git
 gitbranch: master
-inherit: empty
+inherit: cmake
+


### PR DESCRIPTION
From Marcus Leech:

```
Also to note is that simple_ra and gr-ra_blocks are available through
github, and should now be considered the official repo.

https://github.com/patchvonbraun/simple_ra
https://github.com/patchvonbraun/gr-ra_blocks
```
