### PR TITLE
don't install udev rules by default

### DIFF
--- a/hackrf.lwr
+++ b/hackrf.lwr
@@ -26,4 +26,4 @@ inherit: cmake
 configuredir: host/build
 makedir: host/build
 installdir: host/build
-
+var config_opt = " -DINSTALL_UDEV_RULES=OFF"


### PR DESCRIPTION
See https://github.com/mossmann/hackrf/issues/190 - Users may not be
installing system-wide, and may never need udev rules. Additionally
the first item in HackRF's FAQ describes how to install them later if
needed.
