### PR TITLE
rototill flags and fix build

### DIFF
--- a/apache-thrift.lwr
+++ b/apache-thrift.lwr
@@ -23,10 +23,11 @@ source: git://https://git-wip-us.apache.org/repos/asf/thrift.git
 gitbranch: 0.9.2
 inherit: bootstrapautoconf
 configure {
-    ./bootstrap.sh && ./configure --prefix=$prefix $config_opt \
-    --enable-tests --disable-tutorial --with-cpp --with-python \
-    --with-c_glib --with-java --without-csharp --without-php \
-    --without-ruby --without-lua --without-nodejs --without-erlang \
-    --without-go --without-haskell --with-libevent --without-zlib \
+    ./bootstrap.sh && ./configure --prefix=$prefix \
+    --with-c_glib --with-cpp --with-libevent --with-python \
+    --without-csharp --without-d --without-erlang --without-go \
+    --without-haskell --without-java --without-lua --without-nodejs \
+    --without-perl --without-php --without-ruby --without-zlib \
+    --disable-tests --disable-tutorial $config_opt \
     CC=$cc CXX=$cxx PY_PREFIX=$prefix
 }


### PR DESCRIPTION
Disable perl and java too, because the build was trying to use
them and I don't have all the devel bits in place, and was also
trying to install into someplace it ought not.

This is an embedded use; disable the tests on the assumption that
we're using a well tested use point release, and we don't run the
tests anyway.

With all of this flag twiddling going on, sort the flags to show
what is being enabled and what is being disabled.
