### PR TITLE
ldconfig failure shall not be fatal

### DIFF
--- a/gr-gsm.lwr
+++ b/gr-gsm.lwr
@@ -29,5 +29,5 @@ installdir: build
 install {
    cd build
    make install
-   ldconfig
+   ldconfig || true
 }

--- a/osmo-tetra.lwr
+++ b/osmo-tetra.lwr
@@ -32,7 +32,7 @@ make {
 install {
 	cp -v src/libosmo-tetra-mac.a $prefix/lib
 	cp -v src/libosmo-tetra-phy.a $prefix/lib
-	ldconfig -C $prefix/etc/ld.so.cache $prefix/lib
+	ldconfig -C $prefix/etc/ld.so.cache $prefix/lib || true
 	cd src
 	find . -name '*.h' | cpio -pdm $prefix/include/osmo-tetra
 }


### PR DESCRIPTION
When running pybombs as non-root, ldconfig will probably fail. As a user, ldconfig is unnecessary since setup_env.sh will add the target library path to LD_LIBRARY_PATH - this patch masks the failure.
