### PR TITLE
add descriptions to all the recipes

### DIFF
--- a/acarsdec.lwr
+++ b/acarsdec.lwr
@@ -20,10 +20,9 @@
 category: application
 depends: rtl-sdr
 source: wget://http://iweb.dl.sourceforge.net/project/acarsdec/acarsdec/3.1/acarsdec-3.1.tar.gz
-gitbranch: master
+description: open source ACARS decoder with rtl_sdr frontend
 
 make {
-	env > /tmp/envdfg
 	# Note: on non SSE2 processor, it may be necessary to add "-UUSE_SSE2" to CFLAGS
 	# This mess is necessary because the makefile doesn't properly
 	# detect rtlsdr (via pkg-config, for example)

--- a/dump1090.lwr
+++ b/dump1090.lwr
@@ -22,6 +22,7 @@ depends: rtl-sdr
 source: git://https://github.com/mutability/dump1090.git
 gitbranch: master
 inherit: autoconf
+description: simple Mode S decoder for RTLSDR devices
 var config_opt = "-UHTMLPATH -DHTMLPATH=$prefix/share/dump1090"
 
 install {

--- a/gr-acars2.lwr
+++ b/gr-acars2.lwr
@@ -22,3 +22,4 @@ depends: gnuradio
 source: git://https://github.com/antoinet/gr-acars2.git
 gitbranch: master
 inherit: cmake
+description: GNU Radio processing block for ACARS transmissions

--- a/gr-adsb.lwr
+++ b/gr-adsb.lwr
@@ -22,3 +22,4 @@ depends: gnuradio
 source: git://https://github.com/wnagele/gr-adsb.git
 gitbranch: master
 inherit: cmake
+description: GNU Radio ADSB decoder and framer

--- a/gr-air-modes.lwr
+++ b/gr-air-modes.lwr
@@ -23,8 +23,9 @@ satisfy_deb: gr-air-modes
 source: git://https://github.com/bistromath/gr-air-modes.git
 gitbranch: master
 inherit: cmake
+description: Gnuradio Mode-S/ADS-B decoder
 
-# work around lacking paralell cmake dep structure
+# work around lacking parallel cmake dep structure
 make {
     make -j1
     }

--- a/gr-ais.lwr
+++ b/gr-ais.lwr
@@ -22,3 +22,4 @@ depends: gnuradio
 source: git://https://github.com/bistromath/gr-ais.git
 gitbranch: master
 inherit: cmake
+description: Automatic Information System decoder for shipborne position reporting

--- a/gr-ax25.lwr
+++ b/gr-ax25.lwr
@@ -22,3 +22,4 @@ depends: gnuradio
 source: git://https://github.com/dl1ksv/gr-ax25.git
 gitbranch: master
 inherit: cmake
+description: Some hamradio ax.25 routines for gnuradio

--- a/gr-baz.lwr
+++ b/gr-baz.lwr
@@ -22,3 +22,4 @@ depends: gnuradio uhd curl cmake armadillo gr-compat
 source: git://https://github.com/balint256/gr-baz.git
 gitbranch: master
 inherit: cmake
+description: Collection of new blocks for GNU Radio http://wiki.spench.net/wiki/gr-baz

--- a/gr-benchmark.lwr
+++ b/gr-benchmark.lwr
@@ -21,3 +21,4 @@ depends: gnuradio
 category: common
 source: git://https://github.com/osh/gr-benchmark.git
 gitbranch: master
+description: performance measurement tool for GNU Radio

--- a/gr-bluetooth.lwr
+++ b/gr-bluetooth.lwr
@@ -22,3 +22,4 @@ depends: gnuradio gr-compat libbtbb
 source: git://https://github.com/greatscottgadgets/gr-bluetooth.git
 gitbranch: master
 inherit: cmake
+description: Bluetooth receiver implementation for GNU Radio

--- a/gr-burst.lwr
+++ b/gr-burst.lwr
@@ -22,3 +22,4 @@ depends: gnuradio gr-mapper gr-eventstream
 source: git://https://github.com/gr-vt/gr-burst.git
 gitbranch: master
 inherit: cmake
+description: Burst PSK Modem Building Blocks for GNU Radio

--- a/gr-cdma.lwr
+++ b/gr-cdma.lwr
@@ -22,4 +22,4 @@ depends: gnuradio
 source: git://https://github.com/anastas/gr-cdma.git
 gitbranch: master
 inherit: cmake
-
+description: CDMA physical layer for Gnuradio

--- a/gr-compat.lwr
+++ b/gr-compat.lwr
@@ -22,6 +22,8 @@ depends: gnuradio
 source: git://https://github.com/osh/grcompat.git
 gitbranch: master
 inherit: cmake
+description: Compatibility layer for various gnuradio APIs and libraries
+
 install {
     make install
     cd $prefix/include/grcompat/ && ln -sf ../pmt && ln -sf ../gnuradio

--- a/gr-display.lwr
+++ b/gr-display.lwr
@@ -22,3 +22,4 @@ depends: gnuradio
 source: git://https://github.com/dl1ksv/gr-display.git
 gitbranch: master
 inherit: cmake
+description: QT based PNG and text display sink for gnuradio

--- a/gr-drm.lwr
+++ b/gr-drm.lwr
@@ -25,4 +25,4 @@ inherit: cmake
 configuredir: gr-drm/build
 makedir: gr-drm/build
 installdir: gr-drm/build
-
+description: DRM transmitter using GNU Radio

--- a/gr-dsd.lwr
+++ b/gr-dsd.lwr
@@ -22,6 +22,7 @@ depends: mbelib gnuradio libsndfile
 source: git://https://github.com/argilo/gr-dsd.git
 gitbranch: master
 inherit: cmake
+description: GNU Radio block for Digital Speech Decoder
 
 install {
 	make install

--- a/gr-dvbs2.lwr
+++ b/gr-dvbs2.lwr
@@ -22,4 +22,4 @@ depends: gnuradio
 source: git://https://github.com/drmpeg/gr-dvbs2.git
 gitbranch: master
 inherit: cmake
-
+description: DVB-S2 and DVB-S2X transmitter for GNU Radio

--- a/gr-dvbt.lwr
+++ b/gr-dvbt.lwr
@@ -22,3 +22,4 @@ depends: gnuradio
 source: git://https://github.com/BogdanDIA/gr-dvbt.git
 gitbranch: master
 inherit: cmake
+description: DVB-T implementation in gnuradio

--- a/gr-dvbt2.lwr
+++ b/gr-dvbt2.lwr
@@ -22,4 +22,4 @@ depends: gnuradio
 source: git://https://github.com/drmpeg/gr-dvbt2.git
 gitbranch: master
 inherit: cmake
-
+description: DVB-T2 transmitter for GNU Radio

--- a/gr-elster.lwr
+++ b/gr-elster.lwr
@@ -22,4 +22,4 @@ depends: gnuradio
 source: git://https://github.com/argilo/gr-elster.git
 gitbranch: master
 inherit: cmake
-
+description: Decode packets transmitted by Elster R2S smart meters

--- a/gr-ettus.lwr
+++ b/gr-ettus.lwr
@@ -22,3 +22,4 @@ depends: gnuradio uhd
 source: git://https://github.com/EttusResearch/gr-ettus.git
 gitbranch: master
 inherit: cmake
+description: Out-of-tree Module for Experimental Ettus Research Features

--- a/gr-eventstream.lwr
+++ b/gr-eventstream.lwr
@@ -22,3 +22,4 @@ category: common
 source: git://https://github.com/osh/gr-eventstream.git
 gitbranch: master
 inherit: cmake
+description: translation between streams of data and scheduled-finite length events

--- a/gr-fcdproplus.lwr
+++ b/gr-fcdproplus.lwr
@@ -23,3 +23,4 @@ satisfy_deb: gr-fcdproplus && qthid-fcd-controller
 source: git://https://github.com/dl1ksv/gr-fcdproplus.git
 gitbranch: master
 inherit: cmake
+description: gnuradio funcube dongle pro+ source

--- a/gr-fosphor.lwr
+++ b/gr-fosphor.lwr
@@ -25,3 +25,4 @@ gitbranch: master
 #       need to uncomment and update the following line!
 #var config_opt = " -DOPENCL_ROOT_DIR=/usr/lib/nvidia-304-updates/ "
 inherit: cmake
+description: RTSA-like spectrum visualization using OpenCL and OpenGL

--- a/gr-framers.lwr
+++ b/gr-framers.lwr
@@ -22,3 +22,4 @@ depends: gnuradio
 source: git://https://github.com/gr-vt/gr-framers.git
 gitbranch: master
 inherit: cmake
+description: Framer and Deframer Blocks for GNU Radio

--- a/gr-gsm.lwr
+++ b/gr-gsm.lwr
@@ -22,6 +22,7 @@ depends: gnuradio gr-osmosdr scipy liblog4cpp
 source: git://https://github.com/ptrkrysik/gr-gsm.git
 gitbranch: master
 inherit: cmake
+description: Gnuradio blocks and tools for receiving GSM transmissions
 configuredir: build
 makedir: build
 installdir: build

--- a/gr-ham.lwr
+++ b/gr-ham.lwr
@@ -22,4 +22,4 @@ depends: gnuradio gr-compat
 source: git://https://github.com/argilo/gr-ham.git
 gitbranch: master
 inherit: cmake
-
+description: GNU Radio blocks useful for amateur radio

--- a/gr-hpsdr.lwr
+++ b/gr-hpsdr.lwr
@@ -22,3 +22,4 @@ depends: gnuradio
 source: git://https://github.com/Tom-McDermott/gr-hpsdr.git
 gitbranch: master
 inherit: cmake
+description: interface module for HPSDR Hermes / Metis

--- a/gr-ieee-80211.lwr
+++ b/gr-ieee-80211.lwr
@@ -22,4 +22,4 @@ depends: gnuradio uhd libitpp liblog4cpp
 source: git://https://github.com/bastibl/gr-ieee802-11.git
 gitbranch: master
 inherit: cmake
-
+description: IEEE 802.11 a/g/p Transceiver

--- a/gr-ieee-802154.lwr
+++ b/gr-ieee-802154.lwr
@@ -23,4 +23,4 @@ depends: gnuradio uhd
 source: git://https://github.com/bastibl/gr-ieee802-15-4.git
 gitbranch: master
 inherit: cmake
-
+description: IEEE 802.15.4 ZigBee Transceiver

--- a/gr-iio.lwr
+++ b/gr-iio.lwr
@@ -23,3 +23,4 @@ satisfy_deb: gr-iio
 source: git://https://github.com/analogdevicesinc/gnuradio.git
 gitbranch: gr-iio
 inherit: cmake
+description: GNU Radio IIO Blocks

--- a/gr-iqbal.lwr
+++ b/gr-iqbal.lwr
@@ -23,3 +23,4 @@ satisfy_deb: gr-iqbal
 source: git://git://git.osmocom.org/gr-iqbal
 gitbranch: master
 inherit: cmake
+description: gnuradio I/Q balancing

--- a/gr-isdbt.lwr
+++ b/gr-isdbt.lwr
@@ -22,3 +22,4 @@ depends: gnuradio
 source: git://https://github.com/git-artes/gr-isdbt
 gitbranch: master
 inherit: cmake
+description: DTV ISDB-T in GNURadio

--- a/gr-ldpc.lwr
+++ b/gr-ldpc.lwr
@@ -22,4 +22,4 @@ depends: gnuradio
 source: git://https://github.com/manuts/gr-ldpc.git
 gitbranch: master
 inherit: cmake
-
+description: encoder and decoder for LDPC codes

--- a/gr-lte.lwr
+++ b/gr-lte.lwr
@@ -22,3 +22,4 @@ depends: gnuradio gr-osmosdr fftw
 source: git://https://github.com/kit-cel/gr-lte.git
 gitbranch: master
 inherit: cmake
+description: GNU Radio LTE receiver

--- a/gr-mapper.lwr
+++ b/gr-mapper.lwr
@@ -22,3 +22,4 @@ depends: gnuradio
 source: git://https://github.com/gr-vt/gr-mapper.git
 gitbranch: master
 inherit: cmake
+description: Symbol to Bit Mapping and Demapping Blocks for GNU Radio

--- a/gr-mediatools.lwr
+++ b/gr-mediatools.lwr
@@ -22,3 +22,4 @@ depends: gnuradio libav
 source: git://https://github.com/osh/gr-mediatools.git
 gitbranch: master
 inherit: cmake
+description: ffmpeg and gnu radio integration

--- a/gr-message_tools.lwr
+++ b/gr-message_tools.lwr
@@ -22,3 +22,4 @@ depends: gnuradio
 source: git://https://github.com/gr-vt/gr-message_tools.git
 gitbranch: master
 inherit: cmake
+description: Simple message debugging tools

--- a/gr-mtb.lwr
+++ b/gr-mtb.lwr
@@ -25,3 +25,4 @@ inherit: cmake
 configuredir: gr-mtb/build
 makedir: gr-mtb/build
 installdir: gr-mtb/build
+description: GNU Radio measurement toolbox

--- a/gr-multimon.lwr
+++ b/gr-multimon.lwr
@@ -22,3 +22,4 @@ depends: gnuradio
 source: git://https://github.com/ckuethe/gr-multimon.git
 gitbranch: master
 inherit: cmake
+description: multimon gnuradio wrapper

--- a/gr-nacl.lwr
+++ b/gr-nacl.lwr
@@ -22,3 +22,4 @@ category: common
 source: git://https://github.com/stwunsch/gr-nacl.git
 gitbranch: master
 inherit: cmake
+description: GNU Radio module for data encryption using NaCl

--- a/gr-op25.lwr
+++ b/gr-op25.lwr
@@ -22,3 +22,4 @@ depends: gnuradio boost libpcap gr-osmosdr libitpp
 source: git://git://op25.osmocom.org/op25.git
 gitbranch: master
 inherit: cmake
+description: implementation of the APCO Project 25 digital radio standard

--- a/gr-osmosdr.lwr
+++ b/gr-osmosdr.lwr
@@ -23,3 +23,4 @@ satisfy_deb: gr-osmosdr
 source: git://git://git.osmocom.org/gr-osmosdr
 gitbranch: master
 inherit: cmake
+description: interface api independent of the underlying radio hardware

--- a/gr-packetradio.lwr
+++ b/gr-packetradio.lwr
@@ -22,4 +22,4 @@ depends: gnuradio gr-compat
 source: git://https://github.com/balint256/gr-packetradio.git
 gitbranch: master
 inherit: cmake
-
+description: APRS for GNU Radio

--- a/gr-pcap.lwr
+++ b/gr-pcap.lwr
@@ -22,3 +22,4 @@ depends: gnuradio python-scapy
 source: git://https://github.com/osh/gr-pcap.git
 gitbranch: master
 inherit: cmake
+description: PCAP recording and playback

--- a/gr-pocsag.lwr
+++ b/gr-pocsag.lwr
@@ -22,3 +22,4 @@ depends: gnuradio gr-compat
 source: svn://https://www.cgran.org/svn/projects/gr-pocsag/trunk
 gitbranch: master
 inherit: cmake
+description: multichannel POCSAG receiver for gnuradio

--- a/gr-psk-burst.lwr
+++ b/gr-psk-burst.lwr
@@ -22,3 +22,4 @@ depends: gnuradio gr-burst gr-mapper gr-eventstream gr-pyqt
 source: git://https://github.com/osh/gr-psk-burst.git
 gitbranch: master
 inherit: empty
+description: GNU Radio message based burst FSK Transmitter and Receiver

--- a/gr-pyqt.lwr
+++ b/gr-pyqt.lwr
@@ -22,3 +22,4 @@ depends: gnuradio
 source: git://https://github.com/osh/gr-pyqt.git
 gitbranch: master
 inherit: cmake
+description: pyqt based plotters intended for plotting bursted events in gnu radio

--- a/gr-ra_blocks.lwr
+++ b/gr-ra_blocks.lwr
@@ -22,4 +22,4 @@ depends: gnuradio
 source: git://https://github.com/patchvonbraun/gr-ra_blocks.git
 gitbranch: master
 inherit: cmake
-
+description: Helper blocks for simple_ra

--- a/gr-radar.lwr
+++ b/gr-radar.lwr
@@ -22,3 +22,4 @@ category: common
 source: git://https://github.com/kit-cel/gr-radar.git
 gitbranch: master
 inherit: cmake
+description: GNU Radio Radar Toolbox

--- a/gr-rccar2.lwr
+++ b/gr-rccar2.lwr
@@ -22,6 +22,8 @@ depends: gnuradio
 source: git://https://github.com/peterfillmore/GR_RCCar.git
 gitbranch: master
 inherit: cmake
+description: Gnuradio implementation for cheap remote control cars
+
 configuredir: gr-rccar2/build
 makedir: gr-rccar2/build
 installdir: gr-rccar2/build

--- a/gr-rds.lwr
+++ b/gr-rds.lwr
@@ -22,4 +22,4 @@ depends: gnuradio
 source: git://https://github.com/bastibl/gr-rds.git
 gitbranch: master
 inherit: cmake
-
+description: FM RDS/TMC Transceiver

--- a/gr-rtty.lwr
+++ b/gr-rtty.lwr
@@ -22,4 +22,4 @@ depends: gnuradio
 source: git://https://github.com/bistromath/gr-rtty.git
 gitbranch: master
 inherit: cmake
-
+description: RTTY decoder for Gnuradio

--- a/gr-smartnet.lwr
+++ b/gr-smartnet.lwr
@@ -22,3 +22,4 @@ depends: gnuradio gr-compat
 source: git://https://github.com/bistromath/gr-smartnet.git
 gitbranch: master
 inherit: bootstrapautoconf
+description: Motorola Smartnet II trunking logging scanner for Gnuradio

--- a/gr-smithchart.lwr
+++ b/gr-smithchart.lwr
@@ -22,3 +22,4 @@ depends: gnuradio
 source: git://https://github.com/mitul93/gr-smithchart.git
 gitbranch: master
 inherit: cmake
+description: pyQT based smith chart for GNU Radio

--- a/gr-specest.lwr
+++ b/gr-specest.lwr
@@ -22,4 +22,4 @@ depends: gnuradio gfortran lapack blas
 source: git://https://github.com/kit-cel/gr-specest.git
 gitbranch: master
 inherit: cmake
-
+description: spectral estimation routines for GNU Radio

--- a/gr-streamsink.lwr
+++ b/gr-streamsink.lwr
@@ -22,3 +22,4 @@ depends: gnuradio libmp3lame
 source: git://https://github.com/martinleolehner/gr-streamsink.git
 gitbranch: master
 inherit: cmake
+description: GNURadio sink to stream audio to SHOUTcast/Icecast

--- a/gr-tagutils.lwr
+++ b/gr-tagutils.lwr
@@ -22,3 +22,4 @@ depends: gnuradio
 source: git://https://github.com/adamgann/gr-tagutils.git
 gitbranch: master
 inherit: cmake
+description: blocks useful for working with Stream Tags

--- a/gr-theano.lwr
+++ b/gr-theano.lwr
@@ -22,3 +22,4 @@ depends: gnuradio
 source: git://https://github.com/osh/gr-theano.git
 gitbranch: master
 inherit: cmake
+description: Rapid GPU Accelerated Blocks for GNU Radio

--- a/gr-tutorial.lwr
+++ b/gr-tutorial.lwr
@@ -22,4 +22,4 @@ depends: gnuradio liblog4cpp
 source: git://https://github.com/gnuradio/gr-tutorial.git
 gitbranch: master
 inherit: cmake
-
+description: tutorial OOT module for GNU Radio

--- a/gr-uhdgps.lwr
+++ b/gr-uhdgps.lwr
@@ -22,3 +22,4 @@ depends: gnuradio
 source: git://https://github.com/osh/gr-uhdgps.git
 gitbranch: master
 inherit: cmake
+description: Blocks to assist in GPS Data logging with UHD and a GPSDO

--- a/gr-zmqblocks.lwr
+++ b/gr-zmqblocks.lwr
@@ -22,4 +22,4 @@ depends: gnuradio zeromq
 source: git://https://github.com/iohannez/gr-zmqblocks.git
 gitbranch: master
 inherit: cmake
-
+description: connect to flowgraphs over a network to perform remote procedure calls

--- a/pysstv.lwr
+++ b/pysstv.lwr
@@ -2,4 +2,4 @@ depends: python setuptools wget libjpeg
 category: dsplib
 source: wget://https://pypi.python.org/packages/source/P/PySSTV/PySSTV-0.1.9.tar.gz
 inherit: distutils
-
+description: SSTV generator in pure Python

--- a/rtl_433.lwr
+++ b/rtl_433.lwr
@@ -22,3 +22,4 @@ depends: rtl-sdr
 source: git://https://github.com/merbanan/rtl_433.git
 gitbranch: master
 inherit: cmake
+description: 433MHz generic data receiver using RTL2832 DVB dongle

--- a/simple_radio_astronomy.lwr
+++ b/simple_radio_astronomy.lwr
@@ -22,3 +22,4 @@ depends: gnuradio gr-ra_blocks
 source: git://https://github.com/patchvonbraun/simple_ra.git
 gitbranch: master
 inherit: empty
+description: integrated radio astronomy receiver for GNU Radio


### PR DESCRIPTION
This adds a description field to the recipes. I'll be using this to allow pybombs.py and app_store.py to display a brief synopsis of a module's purpose.

Do not merge this PR until is  https://github.com/gnuradio/pybombs/pull/176 is merged as it will cause recipe loading failures.
