### PR TITLE
apache-thrift: disable debug asserts

### DIFF
--- a/apache-thrift.lwr
+++ b/apache-thrift.lwr
@@ -29,5 +29,5 @@ configure {
     --without-haskell --without-java --without-lua --without-nodejs \
     --without-perl --without-php --without-ruby --without-zlib \
     --disable-tests --disable-tutorial $config_opt \
-    CC=$cc CXX=$cxx PY_PREFIX=$prefix
+    CC=$cc CXX=$cxx PY_PREFIX=$prefix CXXFLAGS="-DNDEBUG"
 }


### PR DESCRIPTION
On some platforms apache-thrift throws a debug assert on shutdown due
to an internal bug. This affects GNU Radio apps both during internal
QA testing and regular applications.
