### PR TITLE
Added libosmocore to list of gr-gsm's dependencies

### DIFF
--- a/gr-gsm.lwr
+++ b/gr-gsm.lwr
@@ -18,7 +18,7 @@
 #
 
 category: common
-depends: gnuradio gr-osmosdr scipy liblog4cpp
+depends: gnuradio gr-osmosdr scipy liblog4cpp libosmocore
 source: git://https://github.com/ptrkrysik/gr-gsm.git
 gitbranch: master
 inherit: cmake


### PR DESCRIPTION
Gr-gsm now use encryption/decryption code from libosmocore. There are also plans to use other parts of the library.
