### PR TITLE
Add libad9361 recipe and update gr-iio recipe

### DIFF
--- a/gr-iio.lwr
+++ b/gr-iio.lwr
@@ -18,7 +18,7 @@
 #
 
 category: common
-depends: gnuradio libiio
+depends: gnuradio libiio libad9361
 satisfy_deb: gr-iio
 source: git://https://github.com/analogdevicesinc/gnuradio.git
 gitbranch: gr-iio

--- a/libad9361.lwr
+++ b/libad9361.lwr
@@ -1,0 +1,24 @@
+#
+# This file is part of PyBOMBS
+#
+# PyBOMBS is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3, or (at your option)
+# any later version.
+#
+# PyBOMBS is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with PyBOMBS; see the file COPYING.  If not, write to
+# the Free Software Foundation, Inc., 51 Franklin Street,
+# Boston, MA 02110-1301, USA.
+#
+
+depends: libiio
+category: hardware
+satisfy_deb: libad9361-0 >= 0.1 && libad9361-dev >= 0.1
+source: git://https://github.com/analogdevicesinc/libad9361-iio.git
+inherit: cmake


### PR DESCRIPTION
The libad9361 is a tiny library that contains code specific to the AD9361 transceiver.
The upstream gr-iio now use it inside the newly created FMCOMMS5 blocks.
