### PR TITLE
move acarsdec to my mirror on github

### DIFF
--- a/acarsdec.lwr
+++ b/acarsdec.lwr
@@ -19,7 +19,7 @@
 
 category: application
 depends: rtl-sdr
-source: wget://http://iweb.dl.sourceforge.net/project/acarsdec/acarsdec/3.1/acarsdec-3.1.tar.gz
+source: git://https://github.com/ckuethe/acarsdec.git
 description: open source ACARS decoder with rtl_sdr frontend
 
 make {


### PR DESCRIPTION
I've imported the latest release of acarsdec to a repo here to offer some protection against future hosting site failures.

I'll see if the developer is amenable to putting a repo someplace where this can be automated
