### PR TITLE
update build flags for dump1090

### DIFF
--- a/dump1090.lwr
+++ b/dump1090.lwr
@@ -23,13 +23,4 @@ source: git://https://github.com/mutability/dump1090.git
 gitbranch: master
 inherit: autoconf
 description: simple Mode S decoder for RTLSDR devices
-var config_opt = "-UHTMLPATH -DHTMLPATH=$prefix/share/dump1090"
-
-install {
-	cp -v dump1090 view1090 $prefix/bin
-	cp -r public_html $prefix/share/dump1090
-}
-
-uninstall {
-	rm -rf $prefix/share/dump1090 $prefix/bin/dump1090 $prefix/bin/view1090 
-}
+var config_opt = "PREFIX=$prefix"


### PR DESCRIPTION
<strike>Under active development and has lots of new features.
If you're using a source-reference directory, you'll need to remove dump1090
to pick up the new fork
    git --git-dir=src-reference/.git remote rm dump1090</strike>

This was already pointed at the right repo, but the install behavior is a lot nicer now.
