### PR TITLE
added source to mako.lwr to work on Centos 6

### DIFF
--- a/mako.lwr
+++ b/mako.lwr
@@ -19,6 +19,7 @@
 
 depends: python wget
 category: baseline
+source: wget://https://pypi.python.org/packages/source/M/Mako/Mako-1.0.1.tar.gz
 satisfy_deb: python-mako >= 0.4.2
 satisfy_rpm: python-mako >= 0.4.2
 inherit: distutils


### PR DESCRIPTION
The mako.lwr recipe need a source to work on CentOS 6
