### PR TITLE
Removed 'cd  build' from install part

### DIFF
--- a/gr-gsm.lwr
+++ b/gr-gsm.lwr
@@ -28,7 +28,6 @@ makedir: build
 installdir: build
 
 install {
-   cd build
    make install
    ldconfig || true
 }


### PR DESCRIPTION
Removed 'cd  build' that is causing problems with installation as pybombs is already in build directory when the command is invoked.
