### PR TITLE
fix of pcsclite dependencies

### DIFF
--- a/libudev.lwr
+++ b/libudev.lwr
@@ -1,0 +1,23 @@
+#
+# This file is part of PyBOMBS
+#
+# PyBOMBS is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3, or (at your option)
+# any later version.
+#
+# PyBOMBS is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with PyBOMBS; see the file COPYING.  If not, write to
+# the Free Software Foundation, Inc., 51 Franklin Street,
+# Boston, MA 02110-1301, USA.
+#
+
+category: baseline
+depends:
+satisfy_deb: libudev-dev
+satisfy_rpm: libudev-devel

--- a/pcsclite.lwr
+++ b/pcsclite.lwr
@@ -18,6 +18,7 @@
 #
 
 category: baseline
+depends: flex libudev
 satisfy_deb: libpcsclite-dev >= 1.8.11
 satisfy_rpm: libpcsclite-devel >= 1.8.11
 source: git://git://anonscm.debian.org/pcsclite/PCSC.git


### PR DESCRIPTION
Hi, 

here is a fix for the following problem: 
- libosmocore fails to install on ubuntu systems as it depends on pcsclite
- pcsclite fails to install as it depends on libudev and flex

I therefore added 
- a recipe for libudev for installation via OS - repositories
- dependencies flex and libudev to pcsclite

Best regards,
Roman
