### PR TITLE
recipe for gr-mer

### DIFF
--- a/gr-mer.lwr
+++ b/gr-mer.lwr
@@ -1,0 +1,28 @@
+#
+# This file is part of PyBOMBS
+#
+# PyBOMBS is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3, or (at your option)
+# any later version.
+#
+# PyBOMBS is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with PyBOMBS; see the file COPYING.  If not, write to
+# the Free Software Foundation, Inc., 51 Franklin Street,
+# Boston, MA 02110-1301, USA.
+#
+
+category: common
+depends: gnuradio
+source: git://https://github.com/git-artes/gr-mer
+gitbranch: master
+inherit: cmake
+description: QAM Modulation error measurements.
+
+# GR-MER, QAM Modulation error measurements.
+# An open source implementation of QAM Modulation error measurements in GNU Radio.


### PR DESCRIPTION
GR-MER, QAM Modulation error measurements. An open source implementation of QAM Modulation error measurements in GNU Radio.
