### PR TITLE
Added basic recipes for python-matplotlib and python-tk.

### DIFF
--- a/python-matplotlib.lwr
+++ b/python-matplotlib.lwr
@@ -17,9 +17,7 @@
 # Boston, MA 02110-1301, USA.
 #
 
-category: common
-depends: gnuradio python-matplotlib python-tk
-source: git://https://github.com/osh/gr-pyqt.git
-gitbranch: master
-inherit: cmake
-description: pyqt based plotters intended for plotting bursted events in gnu radio
+depends: python numpy
+category: baseline
+satisfy_deb: python-matplotlib
+description: Python based plotting system in a style similar to Matlab.

--- a/python-tk.lwr
+++ b/python-tk.lwr
@@ -17,9 +17,7 @@
 # Boston, MA 02110-1301, USA.
 #
 
-category: common
-depends: gnuradio python-matplotlib python-tk
-source: git://https://github.com/osh/gr-pyqt.git
-gitbranch: master
-inherit: cmake
-description: pyqt based plotters intended for plotting bursted events in gnu radio
+depends: python
+category: baseline
+satisfy_deb: python-tk
+description: A module for writing portable GUI applications with Python using Tk.


### PR DESCRIPTION
Those are needed to meet the actual dependencies of for example gr-pyqt.
Consequently changed the gr-pyqt recipe as well.
