### PR TITLE
Enable autoconf and automake to be installed from source

### DIFF
--- a/autoconf.lwr
+++ b/autoconf.lwr
@@ -20,5 +20,5 @@
 category: baseline
 satisfy_deb: autoconf >= 2.69
 satisfy_rpm: autoconf >= 2.69
-source: wget://http://ftp.gnu.org/gnu/autoconf/autoconf-2.69.tar.xz
+source: wget://http://ftp.gnu.org/gnu/autoconf/autoconf-2.69.tar.gz
 inherit: autoconf

--- a/autoconf.lwr
+++ b/autoconf.lwr
@@ -18,5 +18,7 @@
 #
 
 category: baseline
-satisfy_deb: autoconf
-satisfy_rpm: autoconf
+satisfy_deb: autoconf >= 2.69
+satisfy_rpm: autoconf >= 2.69
+source: wget://http://ftp.gnu.org/gnu/autoconf/autoconf-2.69.tar.xz
+inherit: autoconf

--- a/automake.lwr
+++ b/automake.lwr
@@ -20,5 +20,5 @@
 category: baseline
 satisfy_deb: automake >= 1.13
 satisfy_rpm: automake >= 1.13
-source: wget://http://ftp.gnu.org/gnu/automake/automake-1.13.4.tar.xz
+source: wget://http://ftp.gnu.org/gnu/automake/automake-1.13.4.tar.gz
 inherit: autoconf

--- a/automake.lwr
+++ b/automake.lwr
@@ -18,5 +18,7 @@
 #
 
 category: baseline
-satisfy_deb: automake
-satisfy_rpm: automake
+satisfy_deb: automake >= 1.13
+satisfy_rpm: automake >= 1.13
+source: wget://http://ftp.gnu.org/gnu/automake/automake-1.13.4.tar.xz
+inherit: autoconf

--- a/automake.lwr
+++ b/automake.lwr
@@ -18,7 +18,7 @@
 #
 
 category: baseline
-satisfy_deb: automake >= 1.13
-satisfy_rpm: automake >= 1.13
-source: wget://http://ftp.gnu.org/gnu/automake/automake-1.13.4.tar.xz
+satisfy_deb: automake >= 1.14
+satisfy_rpm: automake >= 1.14
+source: wget://http://ftp.gnu.org/gnu/automake/automake-1.15.tar.xz
 inherit: autoconf

--- a/automake.lwr
+++ b/automake.lwr
@@ -20,5 +20,5 @@
 category: baseline
 satisfy_deb: automake >= 1.13
 satisfy_rpm: automake >= 1.13
-source: wget://http://ftp.gnu.org/gnu/automake/automake-1.13.4.tar.gz
+source: wget://http://ftp.gnu.org/gnu/automake/automake-1.13.4.tar.xz
 inherit: autoconf

--- a/automake.lwr
+++ b/automake.lwr
@@ -20,5 +20,5 @@
 category: baseline
 satisfy_deb: automake >= 1.14
 satisfy_rpm: automake >= 1.14
-source: wget://http://ftp.gnu.org/gnu/automake/automake-1.15.tar.xz
+source: wget://http://ftp.gnu.org/gnu/automake/automake-1.15.tar.gz
 inherit: autoconf

--- a/pyqt4.lwr
+++ b/pyqt4.lwr
@@ -19,7 +19,7 @@
 
 category: baseline 
 depends: python sip qt4 wget
-satisfy_deb: python-qt4 >= 4.6.2
+satisfy_deb: python-qt4 >= 4.6.2 && ( pyqt4-dev-tools >= 4.6.2 )
 satisfy_rpm: PyQt4-devel >= 4.6.2
 #source: wget://http://pkgs.fedoraproject.org/repo/pkgs/PyQt4/PyQt-x11-gpl-4.6.2.tar.gz/b7aba1b0e41d674b0ebcb64844f442f7/PyQt-x11-gpl-4.6.2.tar.gz
 source: wget://http://pkgs.fedoraproject.org/repo/pkgs/PyQt4/PyQt-x11-gpl-4.7.2.tar.gz/e7782e9146ec8aa0e76bcdb0ca5b9491/PyQt-x11-gpl-4.7.2.tar.gz

--- a/pyqt4.lwr
+++ b/pyqt4.lwr
@@ -19,7 +19,7 @@
 
 category: baseline 
 depends: python sip qt4 wget
-satisfy_deb: python-qt4 >= 4.6.2 && ( pyqt4-dev-tools >= 4.6.2 )
+satisfy_deb: ( python-qt4 >= 4.6.2 ) && ( pyqt4-dev-tools >= 4.6.2 )
 satisfy_rpm: PyQt4-devel >= 4.6.2
 #source: wget://http://pkgs.fedoraproject.org/repo/pkgs/PyQt4/PyQt-x11-gpl-4.6.2.tar.gz/b7aba1b0e41d674b0ebcb64844f442f7/PyQt-x11-gpl-4.6.2.tar.gz
 source: wget://http://pkgs.fedoraproject.org/repo/pkgs/PyQt4/PyQt-x11-gpl-4.7.2.tar.gz/e7782e9146ec8aa0e76bcdb0ca5b9491/PyQt-x11-gpl-4.7.2.tar.gz


### PR DESCRIPTION
Apache-thrift needs newer versions of autoconf and automake. Versions that 14.04 doesn't have.
