### PR TITLE
apache-thrift build: Allow automake and autoconf to build from src

### DIFF
--- a/autoconf.lwr
+++ b/autoconf.lwr
@@ -18,5 +18,7 @@
 #
 
 category: baseline
-satisfy_deb: autoconf
-satisfy_rpm: autoconf
+satisfy_deb: autoconf >= 2.69
+satisfy_rpm: autoconf >= 2.69
+source: wget://http://ftp.gnu.org/gnu/autoconf/autoconf-2.69.tar.gz
+inherit: autoconf

--- a/automake.lwr
+++ b/automake.lwr
@@ -18,5 +18,7 @@
 #
 
 category: baseline
-satisfy_deb: automake
-satisfy_rpm: automake
+satisfy_deb: automake >= 1.14
+satisfy_rpm: automake >= 1.14
+source: wget://http://ftp.gnu.org/gnu/automake/automake-1.15.tar.gz
+inherit: autoconf


### PR DESCRIPTION
Increase minimum version of autoconf and automake for building apache-thrift
