### PR TITLE
gnss-sdr now links against GnuTLS instead of OpenSSL

### DIFF
--- a/gnutls.lwr
+++ b/gnutls.lwr
@@ -17,11 +17,7 @@
 # Boston, MA 02110-1301, USA.
 #
 
-category: application
-depends: gnuradio armadillo gnutls
-source: git://http://github.com/gnss-sdr/gnss-sdr.git
-gitbranch: next
-inherit: cmake
-configuredir: build
-makedir: build
+category: baseline
+satisfy_deb: libgnutls28-dev
+satisfy_rpm: gnutls-devel 
 


### PR DESCRIPTION
Adressing a change of dependency
