### PR TITLE
uhd: add explicit dependency on python-requests (for images downloader)

### DIFF
--- a/python-requests.lwr
+++ b/python-requests.lwr
@@ -17,13 +17,6 @@
 # Boston, MA 02110-1301, USA.
 #
 
-category: hardware
-depends: make swig python python-requests libusb git cmake mako boost gsl numpy cppunit fftw
-satisfy_deb: uhd-host && libuhd-dev
-source: git://https://github.com/EttusResearch/uhd.git
-gitbranch: master
-#gitbranch: rfnoc-devel
-inherit: cmake
-configuredir: host/build
-makedir: host/build
-installdir: host/build
+category: baseline
+satisfy_deb: python-requests
+satisfy_rpm: python-requests


### PR DESCRIPTION
Bare install of Ubuntu 15.04 no longer installs packages which pull in python-requests, and this is needed for the uhd-images-downloader script.
