### PR TITLE
pcsclite: downrev required version to 1.8.10

### DIFF
--- a/pcsclite.lwr
+++ b/pcsclite.lwr
@@ -19,8 +19,8 @@
 
 category: baseline
 depends: flex libudev
-satisfy_deb: libpcsclite-dev >= 1.8.11
-satisfy_rpm: libpcsclite-devel >= 1.8.11
+satisfy_deb: libpcsclite-dev >= 1.8.10
+satisfy_rpm: libpcsclite-devel >= 1.8.10
 source: git://git://anonscm.debian.org/pcsclite/PCSC.git
 inherit: autoconf
 
@@ -28,4 +28,3 @@ configure {
     autoreconf -i
     ./configure --prefix=$prefix $config_opt
 }
-


### PR DESCRIPTION
Per IRC conversation with tnt on #gnuradio, nothing specific is needed from 1.8.11, and Ubuntu 14.04.3 LTS only has 1.8.10 available.
