### PR TITLE
log4cpp - just request the dev package

### DIFF
--- a/liblog4cpp.lwr
+++ b/liblog4cpp.lwr
@@ -19,7 +19,7 @@
 
 depends: libtool automake gcc wget
 category: baseline
-satisfy_deb: liblog4cpp5 && liblog4cpp5-dev
+satisfy_deb: liblog4cpp5-dev
 satisfy_rpm: log4cpp-devel && log4cpp
 source: wget://http://prdownloads.sourceforge.net/log4cpp/log4cpp-1.1.1.tar.gz
 var config_opt = "--with-pthreads"


### PR DESCRIPTION
it will pull in the runtime libraries, and ubuntu changed the package
name in 15.10
