### PR TITLE
libitpp - just require the dev package

### DIFF
--- a/libitpp.lwr
+++ b/libitpp.lwr
@@ -18,4 +18,4 @@
 #
 
 category: baseline
-satisfy_deb: (libitpp7 || libitpp8) && libitpp-dev
+satisfy_deb: libitpp-dev


### PR DESCRIPTION
it will pull in the runtime library. also, ubunutu changed the package
name in 15.10
