### PR TITLE
cppunit - just require the dev library

### DIFF
--- a/cppunit.lwr
+++ b/cppunit.lwr
@@ -19,7 +19,7 @@
 
 category: baseline
 depends: wget
-satisfy_deb: (libcppunit-1.12-1 || libcppunit-1.13-0) && libcppunit-dev
+satisfy_deb: libcppunit-dev
 satisfy_rpm: cppunit-devel
 source: wget://http://prdownloads.sourceforge.net/cppunit/cppunit-1.12.1.tar.gz
 var config_opt = "LIBS=-ldl"


### PR DESCRIPTION
it will pull in the runtime library. also ubuntu changed the package
name in 15.10
