### PR TITLE
gr-iio: Pull from the new repository

### DIFF
--- a/gr-iio.lwr
+++ b/gr-iio.lwr
@@ -20,7 +20,7 @@
 category: common
 depends: gnuradio libiio libad9361
 satisfy_deb: gr-iio
-source: git://https://github.com/analogdevicesinc/gnuradio.git
-gitbranch: gr-iio
+source: git://https://github.com/analogdevicesinc/gr-iio.git
+gitrev: tags/v0.1
 inherit: cmake
 description: GNU Radio IIO Blocks


### PR DESCRIPTION
We also pull from a tag now, since the main branch is a development
branch, and is likely to break things in GNU Radio as the development
advances.

Signed-off-by: Paul Cercueil paul.cercueil@analog.com
